### PR TITLE
Fix package detector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.7
+  - 1.8
   - tip
 
 matrix:
@@ -9,7 +10,10 @@ matrix:
         - go: tip
 
 install:
-  - go get -v gopkg.in/src-d/go-parse-utils.v1
+  - rm -rf $GOPATH/src/gopkg.in/src-d
+  - mkdir -p $GOPATH/src/gopkg.in/src-d
+  - mv $PWD $GOPATH/src/gopkg.in/src-d/go-parse-utils.v1
+  - cd $GOPATH/src/gopkg.in/src-d/go-parse-utils.v1
   - go get -t -v ./...
 
 script:

--- a/ast.go
+++ b/ast.go
@@ -6,19 +6,39 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strings"
 )
 
 // ErrTooManyPackages is returned when there is more than one package in a
 // directory where there should only be one Go package.
 var ErrTooManyPackages = errors.New("more than one package found in a directory")
 
-// PackageAST returs the AST of the package at the given path.
+// PackageAST returns the AST of the package at the given path.
 func PackageAST(path string) (pkg *ast.Package, err error) {
+	return parseAndFilterPackages(path, func(k string, v *ast.Package) bool {
+		return !strings.HasSuffix(k, "_test")
+	})
+}
+
+// PackageTestAST returns the AST of the test package at the given path.
+func PackageTestAST(path string) (pkg *ast.Package, err error) {
+	return parseAndFilterPackages(path, func(k string, v *ast.Package) bool {
+		return strings.HasSuffix(k, "_test")
+	})
+}
+
+type packageFilter func(string, *ast.Package) bool
+
+// filteredPackages filters the parsed packages and then makes sure there is only
+// one left.
+func parseAndFilterPackages(path string, filter packageFilter) (pkg *ast.Package, err error) {
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, filepath.Join(goSrc, path), nil, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}
+
+	pkgs = filterPkgs(pkgs, filter)
 
 	if len(pkgs) != 1 {
 		return nil, ErrTooManyPackages
@@ -29,4 +49,15 @@ func PackageAST(path string) (pkg *ast.Package, err error) {
 	}
 
 	return
+}
+
+func filterPkgs(pkgs map[string]*ast.Package, filter packageFilter) map[string]*ast.Package {
+	filtered := make(map[string]*ast.Package)
+	for k, v := range pkgs {
+		if filter(k, v) {
+			filtered[k] = v
+		}
+	}
+
+	return filtered
 }

--- a/ast_test.go
+++ b/ast_test.go
@@ -1,13 +1,20 @@
-package parseutil
+package parseutil_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-parse-utils.v1"
 )
 
 func TestPackageAST(t *testing.T) {
-	pkg, err := PackageAST(project)
+	pkg, err := parseutil.PackageAST(project)
 	require.Nil(t, err)
 	require.Equal(t, "parseutil", pkg.Name)
+}
+
+func TestPackageTestAST(t *testing.T) {
+	pkg, err := parseutil.PackageTestAST(project)
+	require.Nil(t, err)
+	require.Equal(t, "parseutil_test", pkg.Name)
 }

--- a/importer.go
+++ b/importer.go
@@ -109,7 +109,7 @@ func (i *Importer) ImportFromWithFilters(path, srcDir string, mode types.ImportM
 	}
 	i.mut.Unlock()
 
-	root, files, err := i.getSourceFiles(path, srcDir, filters)
+	root, files, err := i.GetSourceFiles(path, srcDir, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (i *Importer) ImportFromWithFilters(path, srcDir string, mode types.ImportM
 		return pkg, nil
 	}
 
-	pkg, err := i.parseSourceFiles(root, files)
+	pkg, err := i.ParseSourceFiles(root, files)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,8 @@ func (i *Importer) ImportFromWithFilters(path, srcDir string, mode types.ImportM
 	return pkg, nil
 }
 
-func (i *Importer) getSourceFiles(path, srcDir string, filters FileFilters) (string, []string, error) {
+// GetSourceFiles return the go files available in src under path after applying the filters.
+func (i *Importer) GetSourceFiles(path, srcDir string, filters FileFilters) (string, []string, error) {
 	pkg, err := build.Import(path, srcDir, 0)
 	if err != nil {
 		return "", nil, err
@@ -170,7 +171,9 @@ func (i *Importer) getSourceFiles(path, srcDir string, filters FileFilters) (str
 	return pkg.Dir, paths, nil
 }
 
-func (i *Importer) parseSourceFiles(root string, paths []string) (*types.Package, error) {
+// ParseSourceFiles parses the files in paths under root returning a types.Package
+// and an optional error
+func (i *Importer) ParseSourceFiles(root string, paths []string) (*types.Package, error) {
 	var files []*ast.File
 	fs := token.NewFileSet()
 	for _, p := range paths {


### PR DESCRIPTION
Before, if there was a `_test` package an `ErrTooManyPackages` was returned.

This commit makes parseutil deal with it nicely and you can now decide to get
the code package or the test package.

Fixes src-d/proteus#67