### PR TITLE
Use absolute srcDir path in build.Import

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -150,6 +150,10 @@ func (i *Importer) ImportFromWithFilters(path, srcDir string, mode types.ImportM
 
 // GetSourceFiles return the go files available in src under path after applying the filters.
 func (i *Importer) GetSourceFiles(path, srcDir string, filters FileFilters) (string, []string, error) {
+	srcDir, err := filepath.Abs(srcDir)
+	if err != nil {
+		return "", nil, err
+	}
 	pkg, err := build.Import(path, srcDir, 0)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
I was testing [Kallax](https://github.com/src-d/go-kallax) and it was complaining about not finding some package I had vendored.

After some debugging, I tracked it down here. Without this PR I get : 

```bash
> go generate ./kallax_repository.go 
repository.go:6:2: could not import github.com/mohae/deepcopy (cannot find package "github.com/mohae/deepcopy" in any of:
        /my/go/root/src/github.com/mohae/deepcopy (from $GOROOT)
       /my/go/path/src/github.com/mohae/deepcopy (from $GOPATH))
kallax_repository.go:14: running "/path/to/kallax": exit status 1
```
and it is coming from `build.Import`.

After applying this PR, it works as expected.