### PR TITLE
implement GoPath helper and prepare for multiple go paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     allow_failures:
         - go: tip
 
+env:
+  - GOPATH=/tmp/whatever:$GOPATH
+
 install:
   - rm -rf $GOPATH/src/gopkg.in/src-d
   - mkdir -p $GOPATH/src/gopkg.in/src-d

--- a/ast.go
+++ b/ast.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"path/filepath"
 	"strings"
 )
 
@@ -33,7 +32,12 @@ type packageFilter func(string, *ast.Package) bool
 // one left.
 func parseAndFilterPackages(path string, filter packageFilter) (pkg *ast.Package, err error) {
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, filepath.Join(goSrc, path), nil, parser.ParseComments)
+	srcDir, err := DefaultGoPath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs, err := parser.ParseDir(fset, srcDir, nil, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes the issue with not supporting different Gopaths. It also introduces the `GoPath` type, which is a helper to deal with lists of go paths (which will be useful in kallax).