### PR TITLE
Change ImportFrom test to use a vendored package.

### DIFF
--- a/_testdata/vendor/vendoredPkg/vendored.go
+++ b/_testdata/vendor/vendoredPkg/vendored.go
@@ -1,0 +1,1 @@
+package vendoredPkg

--- a/importer_test.go
+++ b/importer_test.go
@@ -75,9 +75,9 @@ func TestImportGoogleGrpc(t *testing.T) {
 
 func TestImportFrom(t *testing.T) {
 	imp := parseutil.NewImporter()
-	pkg, err := imp.ImportFrom(project, "", 0)
+	pkg, err := imp.ImportFrom("vendoredPkg", "_testdata", 0)
 	require.Nil(t, err)
-	require.Equal(t, "parseutil", pkg.Name())
+	require.Equal(t, "vendoredPkg", pkg.Name())
 }
 
 func TestFileFilters(t *testing.T) {


### PR DESCRIPTION
https://golang.org/pkg/go/types/#ImporterFrom is meant for these use cases.

Voluntarily based this off a branch without #6 to show the test failing before, and passing after.