### PR TITLE
Recover simple ImportFrom test

### DIFF
--- a/importer_test.go
+++ b/importer_test.go
@@ -75,6 +75,13 @@ func TestImportGoogleGrpc(t *testing.T) {
 
 func TestImportFrom(t *testing.T) {
 	imp := parseutil.NewImporter()
+	pkg, err := imp.ImportFrom(project, "", 0)
+	require.Nil(t, err)
+	require.Equal(t, "parseutil", pkg.Name())
+}
+
+func TestImportFromVendored(t *testing.T) {
+	imp := parseutil.NewImporter()
 	pkg, err := imp.ImportFrom("vendoredPkg", "_testdata", 0)
 	require.Nil(t, err)
 	require.Equal(t, "vendoredPkg", pkg.Name())


### PR DESCRIPTION
In #9, instead of adding a new test, the previous one was modified. This
commit adds it again.